### PR TITLE
Added unit tests to test the initial setup of the board

### DIFF
--- a/Chess-ChessFinal/Chess.sln
+++ b/Chess-ChessFinal/Chess.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2047
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chess", "Chess-ChessFinal\Chess.csproj", "{F7D2F6C2-1846-43E0-ADDD-6A1C8BCB9EFE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChessUnitTest", "ChessUnitTest\ChessUnitTest.csproj", "{257B3FBB-669A-4989-8247-57B224876ECE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F7D2F6C2-1846-43E0-ADDD-6A1C8BCB9EFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7D2F6C2-1846-43E0-ADDD-6A1C8BCB9EFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7D2F6C2-1846-43E0-ADDD-6A1C8BCB9EFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7D2F6C2-1846-43E0-ADDD-6A1C8BCB9EFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{257B3FBB-669A-4989-8247-57B224876ECE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{257B3FBB-669A-4989-8247-57B224876ECE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{257B3FBB-669A-4989-8247-57B224876ECE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{257B3FBB-669A-4989-8247-57B224876ECE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0D3CDDB5-8862-4353-8777-151583189E45}
+	EndGlobalSection
+EndGlobal

--- a/Chess-ChessFinal/ChessUnitTest/ChessUnitTest.csproj
+++ b/Chess-ChessFinal/ChessUnitTest/ChessUnitTest.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{257B3FBB-669A-4989-8247-57B224876ECE}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ChessUnitTest</RootNamespace>
+    <AssemblyName>ChessUnitTest</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="UnitTest1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Chess-ChessFinal\Chess.csproj">
+      <Project>{f7d2f6c2-1846-43e0-addd-6a1c8bcb9efe}</Project>
+      <Name>Chess</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/Chess-ChessFinal/ChessUnitTest/Properties/AssemblyInfo.cs
+++ b/Chess-ChessFinal/ChessUnitTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ChessUnitTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ChessUnitTest")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("257b3fbb-669a-4989-8247-57b224876ece")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Chess-ChessFinal/ChessUnitTest/UnitTest1.cs
+++ b/Chess-ChessFinal/ChessUnitTest/UnitTest1.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Chess;
+using Chess.Figures;
+
+namespace ChessUnitTest
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void Chess960_InitialSetup_KingIsBetweenTwoRooks_AssertTrue()
+        {
+            Figure[] pieces = new Figure[] {
+                new Bishop('A', 1, true), new Bishop('B', 1, true),
+                new Rook('C', 1, true), new Rook('E', 1, true),
+                new Knight('F', 1, true), new Knight('G', 1, true),
+                new Queen('H', 1, true), new King('D', 1, true)
+            };
+            int rook1 = 0;
+            int rook2 = 0;
+            int king = 0;
+            bool rookFound = false;
+            for (int i = 0; i < 8; i++)
+            {
+                if (pieces[i].GetType() == typeof(Rook))
+                {
+                    if (!rookFound)
+                    {
+                        rook1 = pieces[i].Xpositon;
+                    }
+                    else
+                    {
+                        rook2 = pieces[i].Xpositon;
+                    }
+                }
+                else if (pieces[i].GetType() == typeof(King))
+                {
+                    king = pieces[i].Xpositon;
+                }
+            }
+            Assert.IsTrue((rook1 < king && rook2 > king) || (rook1 > king && rook2 < king), $"{rook1}, {rook2}, {king}");
+        }
+
+        [TestMethod]
+        public void Chess960_InitialSetup_KingIsBetweenTwoRooks_AssertFalse()
+        {
+            Figure[] pieces = new Figure[] {
+                new Bishop('A', 1, true), new Bishop('B', 1, true),
+                new Rook('C', 1, true), new Rook('D', 1, true),
+                new Knight('F', 1, true), new Knight('G', 1, true),
+                new Queen('H', 1, true), new King('E', 1, true)
+            };
+            int rook1 = 0;
+            int rook2 = 0;
+            int king = 0;
+            bool rookFound = false;
+            for (int i = 0; i < 8; i++)
+            {
+                if (pieces[i].GetType() == typeof(Rook))
+                {
+                    if (!rookFound)
+                    {
+                        rook1 = pieces[i].Xpositon;
+                    }
+                    else
+                    {
+                        rook2 = pieces[i].Xpositon;
+                    }
+                }
+                else if (pieces[i].GetType() == typeof(King))
+                {
+                    king = pieces[i].Xpositon;
+                }
+            }
+            Assert.IsFalse((rook1 < king && rook2 > king) || (rook1 > king && rook2 < king), $"{rook1}, {rook2}, {king}");
+        }
+
+        [TestMethod]
+        public void Chess960_InitialSetup_BishopsAreOnDifferentColorSpaces_AssertTrue()
+        {
+            Figure[] pieces = new Figure[] {
+                new Bishop('A', 1, true), new Bishop('B', 1, true),
+                new Rook('C', 1, true), new Rook('E', 1, true),
+                new Knight('F', 1, true), new Knight('G', 1, true),
+                new Queen('H', 1, true), new King('D', 1, true)
+            };
+            int bishop1 = 0;
+            int bishop2 = 0;
+            int king = 0;
+            bool rookFound = false;
+            for (int i = 0; i < 8; i++)
+            {
+                if (pieces[i].GetType() == typeof(Rook))
+                {
+                    if (!rookFound)
+                    {
+                        bishop1 = pieces[i].Xpositon;
+                    }
+                    else
+                    {
+                        bishop2 = pieces[i].Xpositon;
+                    }
+                }
+                else if (pieces[i].GetType() == typeof(King))
+                {
+                    king = pieces[i].Xpositon;
+                }
+            }
+            Assert.IsTrue(bishop1 % 2 != bishop2 % 2, $"{bishop1}, {bishop2}, {king}");
+        }
+
+        [TestMethod]
+        public void Chess960_InitialSetup_BishopsAreOnDifferentColorSpaces_AssertFalse()
+        {
+            Figure[] pieces = new Figure[] {
+                new Bishop('A', 1, true), new Bishop('E', 1, true),
+                new Rook('C', 1, true), new Rook('H', 1, true),
+                new Knight('F', 1, true), new Knight('G', 1, true),
+                new Queen('H', 1, true), new King('D', 1, true)
+            };
+            int bishop1 = 0;
+            int bishop2 = 0;
+            int king = 0;
+            bool rookFound = false;
+            for (int i = 0; i < 8; i++)
+            {
+                if (pieces[i].GetType() == typeof(Rook))
+                {
+                    if (!rookFound)
+                    {
+                        bishop1 = pieces[i].Xpositon;
+                    }
+                    else
+                    {
+                        bishop2 = pieces[i].Xpositon;
+                    }
+                }
+                else if (pieces[i].GetType() == typeof(King))
+                {
+                    king = pieces[i].Xpositon;
+                }
+            }
+            Assert.IsFalse(bishop1 % 2 != bishop2 % 2, $"{bishop1}, {bishop2}, {king}");
+        }
+
+        [TestMethod]
+        public void StandardChess_InitialSetup_BoardIsSetProperly_AssertTrue()
+        {
+            ChessBoard board = new ChessBoard();
+            ChessBox[,] testBoard = new ChessBox[2, 8];
+
+            char c = 'A';
+            bool isWhite = true;
+            for (int x = 0; x < 8; x++)
+            {
+                testBoard[0, x] = new ChessBox(c, 1, isWhite);
+                c++;
+                if (c != 'H')
+                {
+                    isWhite = !isWhite;
+                }
+            }
+
+            c = 'A';
+            for (int x = 0; x < 8; x++)
+            {
+                testBoard[1, x] = new ChessBox(c, 8, isWhite);
+                c++;
+                if (c != 'H')
+                {
+                    isWhite = !isWhite;
+                }
+            }
+
+            testBoard[0, 0].Figure = new Rook('A', 1, false);
+            testBoard[0, 1].Figure = new Knight('B', 1, false);
+            testBoard[0, 2].Figure = new Bishop('C', 1, false);
+            testBoard[0, 3].Figure = new Queen('D', 1, false);
+            testBoard[0, 4].Figure = new King('E', 1, false);
+            testBoard[0, 5].Figure = new Bishop('F', 1, false);
+            testBoard[0, 6].Figure = new Knight('G', 1, false);
+            testBoard[0, 7].Figure = new Rook('H', 1, false);
+            testBoard[1, 0].Figure = new Rook('A', 8, true);
+            testBoard[1, 1].Figure = new Knight('B', 8, true);
+            testBoard[1, 2].Figure = new Bishop('C', 8, true);
+            testBoard[1, 3].Figure = new Queen('D', 8, true);
+            testBoard[1, 4].Figure = new King('E', 8, true);
+            testBoard[1, 5].Figure = new Bishop('F', 8, true);
+            testBoard[1, 6].Figure = new Knight('G', 8, true);
+            testBoard[1, 7].Figure = new Rook('H', 8, true);
+            board.placeBlackFigures(true);
+            board.placeWhiteFigures(true);
+
+            for (int x = 0; x < 8; x++)
+            {
+                if (testBoard[0, x].Figure.GetType() != board.Boxes[0, x].Figure.GetType())
+                {
+                    Assert.IsTrue(false);
+                }
+            }
+
+            for (int x = 0; x < 8; x++)
+            {
+                if (testBoard[1, x].Figure.GetType() != board.Boxes[7, x].Figure.GetType())
+                {
+                    Assert.IsTrue(false);
+                }
+            }
+            Assert.IsTrue(true);
+        }
+    }
+}

--- a/Chess-ChessFinal/ChessUnitTest/packages.config
+++ b/Chess-ChessFinal/ChessUnitTest/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.2.1" targetFramework="net47" />
+  <package id="MSTest.TestFramework" version="1.2.1" targetFramework="net47" />
+</packages>


### PR DESCRIPTION
Added a test for Chess960: The king is between two rooks
Added a test for Chess960: The king is not between two rooks
Added a test for Chess960: The bishops are on opposite colors
Added a test for Chess960: The bishops are on the same colors
Added a test for standard Chess: The board creation is checked against a proper board state